### PR TITLE
Refactored thermostats, so they appear as seperate devices in home assitant.

### DIFF
--- a/danfoss-addon/src/main/java/net/soundvibe/hasio/Bootstrapper.java
+++ b/danfoss-addon/src/main/java/net/soundvibe/hasio/Bootstrapper.java
@@ -191,6 +191,11 @@ public class Bootstrapper {
                         var climateEntity = room.toMQTTClimateEntity(thermostatID, STATE_TOPIC_FMT, SET_TOPIC_FMT, iconMaster);
                         mqttClient.publish(entityTopic, Json.toJsonBytes(climateEntity), 0, false);
 
+                        // 2. Publish battery sensor
+                        var batterySensorEntity = room.toMQTTBatterySensorEntity(thermostatID, STATE_TOPIC_FMT, iconMaster);
+                        var batteryTopic = STR."homeassistant/sensor/\{thermostatID}_battery/config";
+                        mqttClient.publish(batteryTopic, Json.toJsonBytes(batterySensorEntity), 0, false);
+
                         // now publish update to state topic
                         var stateTopic = String.format(STATE_TOPIC_FMT, room.number());
                         var state = room.toState();

--- a/danfoss-addon/src/main/java/net/soundvibe/hasio/danfoss/data/IconRoom.java
+++ b/danfoss-addon/src/main/java/net/soundvibe/hasio/danfoss/data/IconRoom.java
@@ -1,6 +1,7 @@
 package net.soundvibe.hasio.danfoss.data;
 
 import net.soundvibe.hasio.ha.model.MQTTClimateEntity;
+import net.soundvibe.hasio.ha.model.MQTTSensorEntity;
 import net.soundvibe.hasio.ha.model.State;
 
 import java.util.List;
@@ -40,10 +41,10 @@ public record IconRoom(String name, int number, double temperature,
     public MQTTClimateEntity toMQTTClimateEntity(String id, String stateTopicFmt, String setTopicFmt, IconMaster iconMaster) {
         var stateTopic = String.format(stateTopicFmt, number);
         var setTempTopic = String.format(setTopicFmt, number);
-        return new MQTTClimateEntity(id, name, MODES, temperatureLow, temperatureHigh, 0.5,
-                Map.of("name", iconMaster.houseName(), "model", "Icon", "manufacturer", "Danfoss",
+        return new MQTTClimateEntity(id, "Thermostat", MODES, temperatureLow, temperatureHigh, 0.5,
+                Map.of("name", name + " Danfoss Icon", "model", "Icon", "manufacturer", "Danfoss",
                         "hw_version", iconMaster.hardwareRevision(), "sw_version", iconMaster.softwareRevision(),
-                        "identifiers", iconMaster.serialNumber()),
+                        "identifiers", id, "serial_number", iconMaster.serialNumber()),
                 stateTopic, "{{ value_json.attributes.availability }}",
                 stateTopic, "{{ value_json.state }}",
                 stateTopic, "{{ value_json.attributes.mode }}",
@@ -54,6 +55,30 @@ public record IconRoom(String name, int number, double temperature,
                 stateTopic, "{{ value_json.attributes.temperature_target }}", //target temperature state
                 stateTopic, "{{ value_json.attributes.temperature_home }}",
                 stateTopic, "{{ value_json.attributes.temperature_away }}"
+        );
+    }
+
+    public MQTTSensorEntity toMQTTBatterySensorEntity(String id, String stateTopicFmt, IconMaster iconMaster) {
+        var stateTopic = String.format(stateTopicFmt, number);
+
+        return new MQTTSensorEntity(
+            id + "_battery", // unique ID
+            "Battery Level", // friendly name
+            "sensor", // component type
+            String.format(stateTopic, number), // state topic
+            "{{ value_json.attributes.battery_level }}", // value template
+            "%", // unit
+            "battery", // device class
+            "measurement", // state class
+            Map.of(
+                "name", name + " Danfoss Icon",
+                "model", "Icon",
+                "manufacturer", "Danfoss",
+                "hw_version", iconMaster.hardwareRevision(),
+                "sw_version", iconMaster.softwareRevision(),
+                "identifiers", id,
+                "serial_number", iconMaster.serialNumber()
+            )
         );
     }
 

--- a/danfoss-addon/src/main/java/net/soundvibe/hasio/ha/model/MQTTSensorEntity.java
+++ b/danfoss-addon/src/main/java/net/soundvibe/hasio/ha/model/MQTTSensorEntity.java
@@ -1,0 +1,15 @@
+package net.soundvibe.hasio.ha.model;
+
+import java.util.Map;
+
+public record MQTTSensorEntity(
+        String unique_id,
+        String name,
+        String componentType, // should be "sensor"
+        String state_topic,
+        String value_template,
+        String unit_of_measurement,
+        String device_class,
+        String state_class,
+        Map<String, String> device
+) {}


### PR DESCRIPTION
Fan of your project. Some months back i forked it and refactored the thermostats. Saw you now also added some updates why i decided to clean up my fork and setup a pull request.

The thermostats now each get their own unique_id, and therefore each exist as separate devices in home assistant. This better aligns with how each physical thermostat also should be a device in home assistant. This also opens up the possibility of assigning rooms/areas to each thermostat.

I also added a battery sensor to each thermostat so that attribute now automatically gets added to for example the maintenance dashboard in home assistant and you can trend the battery level.

